### PR TITLE
Bundle wintun.dll into Windows builds and installer

### DIFF
--- a/build/windows/Taskfile.yml
+++ b/build/windows/Taskfile.yml
@@ -14,6 +14,11 @@ vars:
   # Docker image for cross-compilation with CGO (used when CGO_ENABLED=1 on non-Windows)
   CROSS_IMAGE: wails-cross
 
+  # wintun.dll — required at runtime by wireguard-go on Windows. Pinned to the
+  # last upstream release; SHA256 from https://www.wintun.net/.
+  WINTUN_VERSION: "0.14.1"
+  WINTUN_SHA256: "07c256185d6ee3652e09fa55c0b673e2624b565e02c4b9091c79ca7d2f24ef51"
+
 tasks:
   build:
     summary: Builds the application for Windows
@@ -40,6 +45,9 @@ tasks:
           DEV:
             ref: .DEV
       - task: common:generate:icons
+      - task: vendor:wintun
+        vars:
+          ARCH: '{{.ARCH | default ARCH}}'
     cmds:
       - task: generate:syso
       - go build {{.BUILD_FLAGS}} -o "{{.BIN_DIR}}/{{.APP_NAME}}.exe"
@@ -60,6 +68,9 @@ tasks:
     deps:
       - task: common:build:frontend
       - task: common:generate:icons
+      - task: vendor:wintun
+        vars:
+          ARCH: '{{.ARCH | default "amd64"}}'
     preconditions:
       - sh: docker info > /dev/null 2>&1
         msg: "Docker is required for CGO cross-compilation. Please install Docker."
@@ -106,6 +117,24 @@ tasks:
       - wails3 generate syso -arch {{.ARCH}} -icon windows/icon.ico -manifest windows/wails.exe.manifest -info windows/info.json -out ../wails_windows_{{.ARCH}}.syso
     vars:
       ARCH: '{{.ARCH | default ARCH}}'
+
+  vendor:wintun:
+    summary: Fetches the official wintun.dll into bin/ (required at runtime by wireguard-go)
+    desc: |
+      wireguard-go loads wintun.dll dynamically at first TUN creation; without
+      it Connect fails with "Error loading wintun.dll DLL: Unable to load
+      library". The official binary is published at https://www.wintun.net/ and
+      pinned here by SHA256.
+    internal: true
+    vars:
+      ARCH: '{{.ARCH | default ARCH}}'
+    status:
+      - test -f "{{.ROOT_DIR}}/{{.BIN_DIR}}/wintun.dll"
+    cmds:
+      - cmd: powershell -NoProfile -ExecutionPolicy Bypass -File "{{.ROOT_DIR}}/build/windows/scripts/vendor-wintun.ps1" -Version "{{.WINTUN_VERSION}}" -Sha256 "{{.WINTUN_SHA256}}" -Arch "{{.ARCH}}" -OutDir "{{.ROOT_DIR}}/{{.BIN_DIR}}"
+        platforms: [windows]
+      - cmd: bash "{{.ROOT_DIR}}/build/windows/scripts/vendor-wintun.sh" "{{.WINTUN_VERSION}}" "{{.WINTUN_SHA256}}" "{{.ARCH}}" "{{.ROOT_DIR}}/{{.BIN_DIR}}"
+        platforms: [linux, darwin]
 
   create:nsis:installer:
     summary: Creates an NSIS installer

--- a/build/windows/nsis/project.nsi
+++ b/build/windows/nsis/project.nsi
@@ -85,8 +85,12 @@ Section
     !insertmacro wails.webview2runtime
 
     SetOutPath $INSTDIR
-    
+
     !insertmacro wails.files
+
+    # wireguard-go loads wintun.dll dynamically from the EXE directory at first
+    # TUN creation. Bundled here by `task vendor:wintun` during build.
+    File "..\..\..\bin\wintun.dll"
 
     CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${PRODUCT_EXECUTABLE}"
     CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${PRODUCT_EXECUTABLE}"

--- a/build/windows/scripts/vendor-wintun.ps1
+++ b/build/windows/scripts/vendor-wintun.ps1
@@ -1,0 +1,36 @@
+#Requires -Version 5
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256,
+    [Parameter(Mandatory=$true)][string]$Arch,
+    [Parameter(Mandatory=$true)][string]$OutDir
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$dllArch = if ($Arch -eq '386') { 'x86' } else { $Arch }
+$url     = "https://www.wintun.net/builds/wintun-$Version.zip"
+$expect  = $Sha256.ToLower()
+$tmpZip  = Join-Path $env:TEMP "wintun-$Version.zip"
+$tmpDir  = Join-Path $env:TEMP ("wintun-extract-" + [guid]::NewGuid())
+
+Write-Host "Downloading $url"
+Invoke-WebRequest -Uri $url -OutFile $tmpZip
+
+$actual = (Get-FileHash -Algorithm SHA256 $tmpZip).Hash.ToLower()
+if ($actual -ne $expect) {
+    throw "wintun.zip SHA256 mismatch. expected=$expect actual=$actual"
+}
+
+Expand-Archive -Force -Path $tmpZip -DestinationPath $tmpDir
+$src = Join-Path $tmpDir "wintun\bin\$dllArch\wintun.dll"
+if (-not (Test-Path $src)) {
+    throw "wintun.dll not found at $src (unknown arch: $dllArch)"
+}
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+Copy-Item $src (Join-Path $OutDir 'wintun.dll') -Force
+Remove-Item -Recurse -Force $tmpDir
+Write-Host "Bundled $dllArch wintun.dll to $OutDir"

--- a/build/windows/scripts/vendor-wintun.sh
+++ b/build/windows/scripts/vendor-wintun.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Downloads the official wintun.dll, verifies SHA256, and copies the arch-
+# appropriate DLL into the given output directory.
+#
+# Usage: vendor-wintun.sh <version> <sha256> <arch> <out_dir>
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+    echo "usage: $0 <version> <sha256> <arch> <out_dir>" >&2
+    exit 2
+fi
+
+VERSION="$1"
+EXPECT="$2"
+ARCH="$3"
+OUT_DIR="$4"
+
+case "$ARCH" in
+    386) DLL_ARCH="x86" ;;
+    *)   DLL_ARCH="$ARCH" ;;
+esac
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+ZIP="$TMP/wintun.zip"
+
+echo "Downloading wintun-$VERSION.zip"
+curl -fsSL "https://www.wintun.net/builds/wintun-$VERSION.zip" -o "$ZIP"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum "$ZIP" | awk '{print $1}')
+else
+    ACTUAL=$(shasum -a 256 "$ZIP" | awk '{print $1}')
+fi
+if [ "$ACTUAL" != "$EXPECT" ]; then
+    echo "wintun.zip SHA256 mismatch. expected=$EXPECT actual=$ACTUAL" >&2
+    exit 1
+fi
+
+unzip -q -o "$ZIP" -d "$TMP/extract"
+SRC="$TMP/extract/wintun/bin/$DLL_ARCH/wintun.dll"
+if [ ! -f "$SRC" ]; then
+    echo "wintun.dll not found at $SRC (unknown arch: $DLL_ARCH)" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+cp "$SRC" "$OUT_DIR/wintun.dll"
+echo "Bundled $DLL_ARCH wintun.dll to $OUT_DIR"


### PR DESCRIPTION
## Summary

- `wireguide.exe` on Windows fails to Connect with `Error loading wintun.dll DLL: Unable to load library` because `wintun.dll` is never placed in `bin/` (or the NSIS installer payload). `wireguard-go` loads it dynamically on the first `tun.CreateTUN`, so the failure surfaces only at Connect time.
- New `windows:vendor:wintun` task downloads `wintun-0.14.1.zip` from `wintun.net`, verifies SHA256, and copies the arch-appropriate DLL to `bin/wintun.dll`. Pinned by SHA256 (`07c256…ef51`) at the top of `build/windows/Taskfile.yml`.
- `windows:build:native` and `windows:build:docker` depend on it; `status:` check makes it a no-op on incremental builds (only fetches when `bin/wintun.dll` is missing).
- NSIS installer picks up `bin/wintun.dll` next to the .exe (already cleaned up by the existing `RMDir /r \$INSTDIR` in the uninstall section).
- Fetch logic lives in `build/windows/scripts/vendor-wintun.{ps1,sh}` rather than inline in the Taskfile — task v3's built-in mvdan/sh interpreter can't parse multi-line PowerShell.

## Test plan

- [x] Tested on Windows 11 ARM64 (the original repro): clean `task build` fetches the DLL and produces a working `bin/wireguide.exe` that loads wintun successfully (helper now has `wintun.dll` mapped, TUN device + routes come up).
- [x] Negative SHA256 test: script exits 1 with `wintun.zip SHA256 mismatch` if the pin doesn't match.
- [x] Incremental build: `vendor:wintun` is skipped via `status:` when `bin/wintun.dll` already present.
- [ ] amd64 build path on Windows / cross-compile path on macOS/Linux (untested here — script handles arch but I only built ARM64).
- [ ] NSIS installer payload verified to contain `wintun.dll` (untested — requires `makensis`; logic is a one-line `File` directive next to the existing `wails.files` macro).

## Notes

Same root cause that bites the official WireGuard for Windows installer — they bundle wintun.dll the same way. The DLL is signed by "Microsoft Windows Hardware Compatibility Publisher" so no extra signing dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)