### PR TITLE
Fix Windows ipc tests: accept self-owned pipe in test binary only

### DIFF
--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -122,7 +122,10 @@ func TestMethodNotFound(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	client, _ := NewClient(addr)
+	client, err := NewClient(addr)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
 	defer client.Close()
 
 	err = client.Call("Does.NotExist", nil, nil)

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -55,6 +55,26 @@ func Dial(addr string) (net.Conn, error) {
 	return conn, nil
 }
 
+// allowSelfOwnedPipes additionally accepts a pipe owned by the current
+// user. It is set only by this package's tests, which create their own
+// listener in-process: an unelevated test binary owns its objects as the
+// user SID, so every dial would otherwise be rejected. Unexported and
+// false in every non-test build, so production always requires SY/BA.
+//
+// An elevated process owns its objects as BA (measured), which is why the
+// helper's real pipe passes the production check.
+var allowSelfOwnedPipes bool
+
+// ownedByCurrentUser reports whether sid is this process's user SID.
+func ownedByCurrentUser(sid *windows.SID) bool {
+	tok := windows.GetCurrentProcessToken()
+	u, err := tok.GetTokenUser()
+	if err != nil {
+		return false
+	}
+	return windows.EqualSid(sid, u.User.Sid)
+}
+
 // verifyPipeOwner checks that the named pipe is owned by Local System (SY)
 // or Built-in Administrators (BA). This prevents a malicious process from
 // creating a pipe with the same name before the legitimate helper starts.
@@ -94,6 +114,10 @@ func verifyPipeOwner(conn net.Conn) error {
 
 	if (localSystem != nil && windows.EqualSid(owner, localSystem)) ||
 		(builtinAdmins != nil && windows.EqualSid(owner, builtinAdmins)) {
+		return nil
+	}
+
+	if allowSelfOwnedPipes && ownedByCurrentUser(owner) {
 		return nil
 	}
 

--- a/internal/ipc/transport_windows_test.go
+++ b/internal/ipc/transport_windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package ipc
+
+// The tests in this package stand up their own pipe listener in-process.
+// `go test` normally runs unelevated, so that pipe is owned by the user SID
+// rather than SY/BA and Dial's verifyPipeOwner would reject every
+// connection. Accept a self-owned pipe for the duration of the test binary
+// so the RPC/framing tests exercise the real transport instead of being
+// skipped -- there is no CI job running them elevated.
+func init() { allowSelfOwnedPipes = true }


### PR DESCRIPTION
## Problem

`go test ./internal/ipc` has been broken on Windows (on `main` and every branch):

- `TestClientServerRPC`, `TestEventBroadcast` — fail with `pipe ownership verification failed: pipe owned by unexpected SID: S-1-5-21-...`
- `TestMethodNotFound` — **panics** (nil deref in `client.Close()`) because it discarded `NewClient`'s error

Root cause: `verifyPipeOwner` accepts only Local System / Built-in Administrators as the pipe owner. The tests create their own listener in-process, and an unelevated `go test` owns that pipe as the user SID → every dial rejected.

## Fix

- `allowSelfOwnedPipes` package var in `transport_windows.go`, set **only** by a `_test.go` `init()`. Production builds never set it — the SY/BA requirement is byte-for-byte unchanged for real clients (this is deliberately NOT a loosening of the check that #20 concerns).
- `TestMethodNotFound` now checks `NewClient`'s error instead of dereferencing nil.

## Why not skip when unelevated?

There is no CI job that runs `go test` (`release.yml` is the only workflow — filed separately), so `t.Skip` would leave the Windows ipc transport with zero coverage anywhere, forever. With this fix the tests exercise the real named-pipe transport unelevated.

## Empirical note

Measured with a throwaway probe using the helper's exact SDDL: an **elevated** process owns its pipe as `BUILTIN\Administrators` (S-1-5-32-544), so the real helper pipe passes the strict production check. This also disproves the earlier "helper must run as SYSTEM to own objects as Administrators" theory from the 2026-05-23 debugging notes — the UAPI protected-namespace failure has some other cause.

## Verification (Windows 11, real run)

- `go test -count=1 ./internal/ipc` — all pass, via the real transport (not skipped)
- `go vet ./...`, `go build ./...`, `go build -tags production ./...` — clean
- `GOOS=darwin` / `GOOS=linux` builds of the package — unaffected (file is `//go:build windows`)
- `grep -rn allowSelfOwnedPipes` — only assignment is in `transport_windows_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
