### PR TITLE
fix(windows): tray left-click/Show Window/menu state + installer file-lock

### DIFF
--- a/build/windows/nsis/project.nsi
+++ b/build/windows/nsis/project.nsi
@@ -91,6 +91,15 @@ FunctionEnd
 Section
     !insertmacro wails.setShellContext
 
+    # The GUI tray app and the elevated helper are the same exe, and Windows
+    # locks running images — without this, an in-place upgrade dies with
+    # "Error opening file for writing: wireguide.exe". The installer runs
+    # elevated, so taskkill reaches the SYSTEM-level helper too. Exit code is
+    # ignored: 128 just means nothing was running.
+    nsExec::ExecToLog `taskkill /F /IM "${PRODUCT_EXECUTABLE}"`
+    Pop $0
+    Sleep 500
+
     !insertmacro wails.webview2runtime
 
     SetOutPath $INSTDIR
@@ -131,8 +140,14 @@ Section
     !insertmacro wails.writeUninstaller
 SectionEnd
 
-Section "uninstall" 
+Section "uninstall"
     !insertmacro wails.setShellContext
+
+    # Same as install: both the tray app and the helper hold the exe image
+    # open, so RMDir /r would silently leave wireguide.exe behind.
+    nsExec::ExecToLog `taskkill /F /IM "${PRODUCT_EXECUTABLE}"`
+    Pop $0
+    Sleep 500
 
     RMDir /r "$AppData\${PRODUCT_EXECUTABLE}" # Remove the WebView2 DataPath
 

--- a/internal/gui/dock_other.go
+++ b/internal/gui/dock_other.go
@@ -6,5 +6,23 @@ import "github.com/wailsapp/wails/v3/pkg/application"
 
 var dockWindow *application.WebviewWindow
 
-func showDock() {}
+// showDock brings back the main window after close-to-tray. Unlike macOS
+// there is no dock icon / activation policy to juggle (and no async retry
+// dance) — un-minimise + Show + Focus on the window is the whole job.
+// Restore comes first: Show() alone does not un-minimise on Windows, so a
+// window hidden while minimised would otherwise reappear only in the
+// taskbar, still collapsed.
+func showDock() {
+	if dockWindow == nil {
+		return
+	}
+	if dockWindow.IsMinimised() {
+		dockWindow.Restore()
+	}
+	dockWindow.Show()
+	dockWindow.Focus()
+}
+
+// hideDock only exists to hide the macOS dock icon — the window itself is
+// already hidden by the WindowClosing hook, so there is nothing to do here.
 func hideDock() {}

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -226,6 +226,14 @@ func Run(assetsHandler http.Handler, dataDir string) error {
 		if runtime.GOOS == "windows" && len(trayOffIconWindows) > 0 {
 			tray.SetIcon(trayOffIconWindows)
 		}
+		// Windows convention: left-click on a tray icon is the primary
+		// action — show the main window (WireGuard-for-Windows, Discord,
+		// Slack all behave this way); the menu stays on right-click.
+		// Registered only here: on macOS any click opens the NSStatusItem
+		// menu natively, and an OnClick handler would fight it.
+		if runtime.GOOS == "windows" {
+			tray.OnClick(showDock)
+		}
 	}
 	tray.SetTooltip("WireGuide")
 

--- a/internal/gui/tray.go
+++ b/internal/gui/tray.go
@@ -642,9 +642,15 @@ func (t *trayManager) rebuildMenu() {
 		t.tray.Destroy()
 		t.app.Quit()
 	})
-	if created {
+	if created || runtime.GOOS == "windows" {
+		// Windows must go through SetMenu on EVERY rebuild: the tray popup
+		// is a separate PopupMenu that only SetMenu reconstructs, while
+		// Menu.Update() refreshes a window-menu impl the popup never reads —
+		// so refilled items (connection glyphs) stayed invisible forever.
 		t.tray.SetMenu(m) // runs m.Update() and caches the NSMenu
 	} else {
-		m.Update() // in-place refresh of the same NSMenu — live even while open
+		// macOS: in-place refresh of the same NSMenu — live even while
+		// open, and repeated SetMenu there leaked the replaced NSMenu.
+		m.Update()
 	}
 }


### PR DESCRIPTION
## Summary

Two Windows fixes, both verified live on Windows 11 with a dev build:

### Tray fixes (Fixes #30)

Three Windows-only defects, all rooted in macOS-first implementations:

- `showDock()` was an empty stub on `!darwin` (`dock_other.go`), so the tray menu's "Show Window" did nothing and — combined with the cross-platform close-to-tray hook — **a closed window was unrecoverable without killing the process**. Now un-minimises + shows + focuses the main window (also fixes Linux).
- No tray `OnClick` handler existed, so left-click was a no-op. Windows now maps left-click to show-window per platform convention (WireGuard-for-Windows, Discord, Slack); macOS keeps its native any-click-opens-menu behavior.
- `rebuildMenu` only called `SetMenu` on the first build and `Menu.Update()` afterwards. On Windows the tray popup is a separate `PopupMenu` that only `SetMenu` reconstructs — `Menu.Update()` refreshes a window-menu impl the popup never reads — so connection glyphs (○/●) were frozen at launch-time state while the icon/tooltip (separate `SetIcon` path) updated correctly. Windows now goes through `SetMenu` on every rebuild; the macOS in-place `Update()` path is unchanged (repeated `SetMenu` there leaked NSMenus).

### Installer fix (Fixes #29)

The GUI and the elevated helper are the same `wireguide.exe`; Windows locks running images, so in-place upgrades died with "Error opening file for writing". `taskkill /F` before file operations in both install and uninstall sections (the installer runs elevated, so it reaches the SYSTEM-level helper). Ships with the next release (0.4.2) — the published v0.4.1 asset is deliberately left untouched to keep `SHA256SUMS` + Ed25519 signature valid.

## Test plan

- [x] Left-click tray icon shows/focuses the window
- [x] Close window (X) → left-click reopens it (previously unrecoverable)
- [x] Right-click → "Show Window" reopens it
- [x] Right-click menu shows live ○/◐/● connection state, tracks connect/disconnect
- [x] `go build ./...` + `go vet` clean; macOS paths untouched (build-tag gated)
- [ ] NSIS change takes effect at next packaged release (verified manually via elevated `taskkill` + silent install of 0.4.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
