### PR TITLE
Add --json flag to status + list cmd

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,12 +8,14 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -78,8 +80,8 @@ func usage(w io.Writer) {
 	fmt.Fprint(w, `wireguide ctl — control the WireGuide helper from the command line
 
 Tunnels:
-  wireguide ctl status                    show connection status
-  wireguide ctl list                      list tunnels (● = connected)
+  wireguide ctl status [--json]           show connection status
+  wireguide ctl list [--json]             list tunnels (● = connected)
   wireguide ctl connect <name>            connect a tunnel
   wireguide ctl disconnect [name]         disconnect one tunnel (or all)
   wireguide ctl import <file> [name]      import a .conf (name defaults to filename)
@@ -153,7 +155,9 @@ func tunnelStore() (*storage.TunnelStore, error) {
 	return storage.NewTunnelStore(paths.TunnelsDir), nil
 }
 
-func cmdStatus(_ []string) int {
+func cmdStatus(args []string) int {
+	jsonOut := hasFlag(args, "--json")
+
 	c, err := dialHelper()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -167,6 +171,9 @@ func cmdStatus(_ []string) int {
 		return 1
 	}
 	if len(active.Names) == 0 {
+		if jsonOut {
+			return printJSON([]domain.ConnectionStatus{})
+		}
 		fmt.Println("disconnected")
 		return 0
 	}
@@ -180,6 +187,9 @@ func cmdStatus(_ []string) int {
 	if len(rows) == 0 {
 		rows = []domain.ConnectionStatus{st}
 	}
+	if jsonOut {
+		return printJSON(rows)
+	}
 	for _, r := range rows {
 		hs := r.LastHandshake
 		if hs == "" {
@@ -191,7 +201,16 @@ func cmdStatus(_ []string) int {
 	return 0
 }
 
-func cmdList(_ []string) int {
+// tunnelListEntry is the --json shape for `ctl list`; domain.ConnectionStatus
+// doesn't apply here since a listed tunnel may never have been connected.
+type tunnelListEntry struct {
+	Name   string `json:"name"`
+	Active bool   `json:"active"`
+}
+
+func cmdList(args []string) int {
+	jsonOut := hasFlag(args, "--json")
+
 	store, err := tunnelStore()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "list:", err)
@@ -214,6 +233,13 @@ func cmdList(_ []string) int {
 		}
 		c.Close()
 	}
+	if jsonOut {
+		entries := make([]tunnelListEntry, len(names))
+		for i, n := range names {
+			entries[i] = tunnelListEntry{Name: n, Active: activeSet[n]}
+		}
+		return printJSON(entries)
+	}
 	if len(names) == 0 {
 		fmt.Println("(no tunnels)")
 		return 0
@@ -225,6 +251,23 @@ func cmdList(_ []string) int {
 		}
 		fmt.Printf("%s %s\n", marker, n)
 	}
+	return 0
+}
+
+// hasFlag reports whether flag is present anywhere in args.
+func hasFlag(args []string, flag string) bool {
+	return slices.Contains(args, flag)
+}
+
+// printJSON marshals v as indented JSON to stdout. Always returns 0 unless
+// marshalling itself fails.
+func printJSON(v any) int {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "json:", err)
+		return 1
+	}
+	fmt.Println(string(data))
 	return 0
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a `--json` flag to the `status` and `list` ctl commands.

## Why?

Plain-text formatting requires the usage of regex matching or other advanced parsing methods which are error-prone and must be adapted when output format changes.

Supporting JSON as an output variant eases machine parsing of tunnels and their connection status.

## How to test

1. Build binary
2. Run `./bin/wireguide ctl list --json` and parse with `jq`

## Checklist

- [x] Tested on macOS (Apple Silicon)
- [x] No new warnings from `go build ./...`
- [x] Relevant code comments added (if non-obvious logic)
